### PR TITLE
modified seed-from-info behavior

### DIFF
--- a/FlashXTest/lib/info.py
+++ b/FlashXTest/lib/info.py
@@ -281,7 +281,7 @@ def createInfo(mainDict, specList):
                             ][0]
 
                     nlist = testSpec.getXmlText()
-                    nlist += xmlText # This list mnow has items from the
+                    nlist += xmlText # This list now has items from the
                     # test spec, followed by items from the seed-info file
 
                     # Now turn the combined list into a dict. Last
@@ -291,9 +291,12 @@ def createInfo(mainDict, specList):
                         fieldName = entries.split(":")[0].strip()
                         fieldVal  = entries.split(":")[1].strip()
                         if fieldName:
-                          ndict[fieldName] = fieldVal
+                            if (fieldName in ndict and ndict[fieldName] != None  and
+                                fieldName == "setupOptins" and mainDict["addSetupOptions"]):
+                                fieldVal = fieldVal + " " + mainDict["addSetupOptions"].strip()
+                            ndict[fieldName] = fieldVal
 
-                    # back fro ma dict to something like a list:
+                    # back from a dict to something like a list:
                     infoNode.findChildrenWithPath(testSpec.nodeName)[
                         0
                     ].text = (": ".join(it) for it in ndict.items())


### PR DESCRIPTION
This implements my version / vision of the --seed-from-info behavior. I found it useful and usable in some local experimentation, using Flash-X-testbranch on GCE Jenkins.

This branch simply has some commits on top of `adhruv/seedFromInfo` which had been established by @akashdhruv .